### PR TITLE
Remove the unneeded ImgLib1 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,6 @@
 			<artifactId>ij</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>sc.fiji</groupId>
-			<artifactId>legacy-imglib1</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>mpicbg</groupId>
 			<artifactId>mpicbg</artifactId>
 		</dependency>


### PR DESCRIPTION
We got rid of all the ImgLib1 usage in Descriptor based registration, so
it is time to move on now.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
