### PR TITLE
bump to pom-bigdataviewer 4.0.1 versions and SPIM_Registration to 5.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,8 @@
 
 	<properties>
 		<scijava.jvm.version>1.8</scijava.jvm.version>
-		<SPIM_Registration.version>5.0.7</SPIM_Registration.version>
+		<SPIM_Registration.version>5.0.8</SPIM_Registration.version>
+		<pom-bigdataviewer.version>4.0.1</pom-bigdataviewer.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
bump to pom-bigdataviewer 4.0.1 versions and SPIM_Registration version 5.0.8.
This is to make Descriptor_based_registration compatible to SPIM_Registration 5.0.8, once that is released. Not sure if it's necessary, but better to be sure...